### PR TITLE
Add onnx to common_methods_invocations.py approvers

### DIFF
--- a/.github/merge_rules.yaml
+++ b/.github/merge_rules.yaml
@@ -17,6 +17,7 @@
   - torch/csrc/jit/serialization/onnx.*
   - torch/csrc/onnx/**
   - torch/onnx/**
+  - torch/testing/_internal/common_methods_invocations.py
   - third_party/onnx
   - caffe2/python/onnx/**
   approved_by:


### PR DESCRIPTION
Add onnx to common_methods_invocations.py approvers so that the torch.onnx group can contribute OpInfos and add skips.
